### PR TITLE
Fix "Luftdaten-Viewer Grafana" documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Luftdatenpumpe changelog
 
 in progress
 ===========
+- Fix "Luftdaten-Viewer Grafana" documentation section about
+  exporting station metadata from PostGIS to JSON file.
+  Thanks, @ohobby.
 
 
 2022-12-05 0.21.1

--- a/doc/setup/ldview-grafana-irceline.rst
+++ b/doc/setup/ldview-grafana-irceline.rst
@@ -52,7 +52,7 @@ Create station list file for Grafana Worldmap Panel from RDBMS database (Postgre
     stationsfile=/var/lib/grafana/data/json/vmm-stations.json
     # macOS: stationsfile=/usr/local/var/lib/grafana/data/json/vmm-stations.json
 
-    luftdatenpumpe stations --source=postgresql://luftdatenpumpe@localhost/weatherbase --target=json.flex+stream://sys.stdout --target-fieldmap='key=station_id\|str,name=sos_feature_and_id' > $stationsfile
+    luftdatenpumpe stations --source=postgresql://luftdatenpumpe@localhost/weatherbase --target=json.flex+stream://sys.stdout --target-fieldmap='key=station_id|str,name=sos_feature_and_id' > $stationsfile
 
 Worldmap Panel IRCELINE::
 

--- a/doc/setup/ldview-grafana.rst
+++ b/doc/setup/ldview-grafana.rst
@@ -88,7 +88,7 @@ Create RDBMS database view ``ldi_network``::
 
 Create station list file for Grafana Worldmap Panel from RDBMS database (PostgreSQL)::
 
-    luftdatenpumpe stations --source=postgresql://luftdatenpumpe@localhost/weatherbase --target=json.flex+stream://sys.stdout --target-fieldmap='key=station_id\|str,name=road_and_name_and_id' > $stationsfile
+    luftdatenpumpe stations --source=postgresql://luftdatenpumpe@localhost/weatherbase --target=json.flex+stream://sys.stdout --target-fieldmap='key=station_id|str,name=road_and_name_and_id' > $stationsfile
 
 Check::
 


### PR DESCRIPTION
The section about exporting station metadata from PostGIS to JSON file was wrong, and included an erroneous backslash character.