### PR TITLE
Add OSM-based synthetic geolocation field for micro-regions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ in progress
 - Fix "Luftdaten-Viewer Grafana" documentation section about
   exporting station metadata from PostGIS to JSON file.
   Thanks, @ohobby.
+- Add OSM-based synthetic geolocation field for micro-regions.
+  Thanks, @ohobby.
 
 
 2022-12-05 0.21.1

--- a/luftdatenpumpe/target/rdbms.py
+++ b/luftdatenpumpe/target/rdbms.py
@@ -326,6 +326,7 @@ class RDBMSStorage:
 
               -- Synthesized fields.
               concat('(#', CAST({prefix}_stations.station_id AS text), ')') AS station_id_suffix,
+              concat('(#', CAST({prefix}_sensors.sensor_id AS text), ')') AS sensor_id_suffix,
               concat('(', {prefix}_osmdata.osm_country_code, ')') AS country_code_suffix,
 
               -- OSM fields.
@@ -349,6 +350,8 @@ class RDBMSStorage:
               concat(concat_ws(', ', osm_state, osm_country), ' ', country_code_suffix) AS state_and_country,
               concat(concat_ws(', ', osm_city, osm_state, osm_country), ' ', country_code_suffix)
                 AS city_and_state_and_country,
+              concat(concat_ws(', ', osm_state_district, osm_postcode, osm_city), ' ', sensor_id_suffix)
+                AS district_postcode_city_sensorid,
               {self.render_fields(conditional_fields_stage2)}
               ABS(DATE_PART('day', sensor_last_date - now())) <= 7 AS is_active
 


### PR DESCRIPTION
Dear @ohobby,

at [Luftdatenpumpe: Aiming to focus on sensor id instead of station id](https://community.panodata.org/t/luftdatenpumpe-aiming-to-focus-on-sensor-id-instead-of-station-id/254/9), you asked about a different formatting of the popup label when displaying measurement values on the [Panodata Map Panel](https://github.com/panodata/panodata-map-panel).

This patch adds a corresponding improvement.

```
Field:   district_postcode_city_sensorid
Format:  District, Postcode, City (#SensorID)
Example: Regierungsbezirk Darmstadt, 60385, Frankfurt (#76777)
```

The new field can then be used on the step when exporting station metadata from PostGIS to JSON for the map panel:
```
luftdatenpumpe stations \
  --network=ldi \
  --source=postgresql://luftdatenpumpe@localhost/weatherbase \
  --target=json.flex+stream://sys.stdout \
  --target-fieldmap='key=station_id|str,name=district_postcode_city_sensorid'
```

You can update the installation within your virtualenv to the version within this branch on GitHub by running:
```
pip install --upgrade git+https://github.com/earthobservations/luftdatenpumpe@popup-label-dpcs
```

With kind regards,
Andreas.
