### PR TITLE
Adjust OSM-based synthetic geolocation fields for micro-regions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,9 @@ in progress
 - Fix "Luftdaten-Viewer Grafana" documentation section about
   exporting station metadata from PostGIS to JSON file.
   Thanks, @ohobby.
-- Add OSM-based synthetic geolocation field for micro-regions.
-  Thanks, @ohobby.
+- Add two new OSM-based synthetic geolocation fields for better
+  addressing of micro-regions, ``district_postcode_city_sensorid``,
+  and ``suburb_postcode_city_sensorid``. Thanks, @ohobby.
 
 
 2022-12-05 0.21.1

--- a/luftdatenpumpe/target/rdbms.py
+++ b/luftdatenpumpe/target/rdbms.py
@@ -350,8 +350,10 @@ class RDBMSStorage:
               concat(concat_ws(', ', osm_state, osm_country), ' ', country_code_suffix) AS state_and_country,
               concat(concat_ws(', ', osm_city, osm_state, osm_country), ' ', country_code_suffix)
                 AS city_and_state_and_country,
-              concat(concat_ws(', ', osm_state_district, osm_postcode, osm_city), ' ', sensor_id_suffix)
+              concat(osm_state_district, ', ', osm_postcode, ' ', osm_city, ' ', sensor_id_suffix)
                 AS district_postcode_city_sensorid,
+              concat(osm_suburb, ', ', osm_postcode, ' ', osm_city, ' ', sensor_id_suffix)
+                AS suburb_postcode_city_sensorid,
               {self.render_fields(conditional_fields_stage2)}
               ABS(DATE_PART('day', sensor_last_date - now())) <= 7 AS is_active
 


### PR DESCRIPTION
Some adjustments as a followup to #52. See also https://community.panodata.org/t/luftdatenpumpe-aiming-to-focus-on-sensor-id-instead-of-station-id/254/11 ff.

```
Field:   district_postcode_city_sensorid
Format:  District, Postcode City (#SensorID)
Example: Regierungsbezirk Darmstadt, 60385 Frankfurt (#76777)

Field:   suburb_postcode_city_sensorid
Format:  Suburb, Postcode City (#SensorID)
Example: Eckenheim, 60435 Frankfurt (#65567)
```
